### PR TITLE
MNT Add generic type arguments to Injector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "silverstripe/versioned": "^2",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.7",
+        "phpstan/phpstan": "^1.10"
     },
     "conflict": {
         "egulias/email-validator": "^2",
@@ -97,7 +98,8 @@
             "SilverStripe\\Security\\Tests\\": "tests/php/Security/",
             "SilverStripe\\View\\": "src/View/",
             "SilverStripe\\View\\Tests\\": "tests/php/View/",
-            "SilverStripe\\Framework\\Tests\\Behaviour\\": "tests/behat/src/"
+            "SilverStripe\\Framework\\Tests\\Behaviour\\": "tests/behat/src/",
+            "SilverStripe\\Type\\Tests\\": "tests/php/Type/"
         },
         "files": [
             "src/includes/constants.php"

--- a/src/Core/Injector/Injector.php
+++ b/src/Core/Injector/Injector.php
@@ -856,8 +856,6 @@ class Injector implements ContainerInterface
      *
      * Will recursively call itself for each depth of dotting.
      *
-     * @template T of object
-     * @param class-string<T>|string
      */
     public function has(string $name): bool
     {
@@ -896,10 +894,8 @@ class Injector implements ContainerInterface
      * Register a service object with an optional name to register it as the
      * service for
      *
-     * @template TService of object
-     * @template TReplace of object
-     * @param TService $service The object to register
-     * @param class-string<TReplace>|string|null $replace The name of the object to replace (if different to the
+     * @param object $service The object to register
+     * @param string $replace The name of the object to replace (if different to the
      * class name of the object to register)
      * @return $this
      */
@@ -919,8 +915,7 @@ class Injector implements ContainerInterface
      * Removes a named object from the cached list of objects managed
      * by the inject
      *
-     * @template T of object
-     * @param class-string<T>|string $name The name to unregister
+     * @param string $name The name to unregister
      * @return $this
      */
     public function unregisterNamedObject($name)
@@ -977,7 +972,8 @@ class Injector implements ContainerInterface
      * @param bool $asSingleton If set to false a new instance will be returned.
      * If true a singleton will be returned unless the spec is type=prototype'
      * @param array $constructorArgs Args to pass in to the constructor. Note: Ignored for singletons
-     * @return ($name is class-string<T> ? T : mixed) Instance of the specified object
+     * @return mixed Instance of the specified object
+     * @phpstan-return ($name is class-string<T> ? T : mixed) Instance of the specified object
      */
     public function get($name, $asSingleton = true, $constructorArgs = [])
     {
@@ -993,13 +989,12 @@ class Injector implements ContainerInterface
     /**
      * Returns the service, or `null` if it doesnt' exist. See {@link get()} for main usage.
      *
-     * @template T of object
-     * @param class-string<T> $name The name of the service to retrieve. If not a registered
+     * @param string $name The name of the service to retrieve. If not a registered
      * service, then a class of the given name is instantiated
      * @param bool $asSingleton If set to false a new instance will be returned.
      * If true a singleton will be returned unless the spec is type=prototype'
      * @param array $constructorArgs Args to pass in to the constructor. Note: Ignored for singletons
-     * @return ($name is class-string<T> ? T : mixed) Instance of the specified object
+     * @return mixed Instance of the specified object
      */
     protected function getNamedService($name, $asSingleton = true, $constructorArgs = [])
     {
@@ -1135,7 +1130,8 @@ class Injector implements ContainerInterface
      * @template T of object
      * @param class-string<T> $name
      * @param mixed ...$argument arguments to pass to the constructor
-     * @return ($name is class-string<T> ? T : mixed) A new instance of the specified object
+     * @return mixed A new instance of the specified object
+     * @phpstan-return ($name is class-string<T> ? T : mixed) A new instance of the specified object
      */
     public function create($name, $argument = null)
     {
@@ -1147,10 +1143,11 @@ class Injector implements ContainerInterface
     /**
      * Creates an object with the supplied argument array
      *
-     * @template T of object
-     * @param class-string<T>|string $name Name of the class to create an object of
+     * @template T
+     * @param class-string<T> $name Name of the class to create an object of
      * @param array $constructorArgs Arguments to pass to the constructor
-     * @return ($name is class-string<T> ? T : mixed)
+     * @return mixed
+     * @phpstan-return ($name is class-string<T> ? T : mixed)
      */
     public function createWithArgs($name, $constructorArgs)
     {

--- a/src/Core/Injector/Injector.php
+++ b/src/Core/Injector/Injector.php
@@ -856,6 +856,8 @@ class Injector implements ContainerInterface
      *
      * Will recursively call itself for each depth of dotting.
      *
+     * @template T of object
+     * @param class-string<T>|string
      */
     public function has(string $name): bool
     {
@@ -894,8 +896,10 @@ class Injector implements ContainerInterface
      * Register a service object with an optional name to register it as the
      * service for
      *
-     * @param object $service The object to register
-     * @param string $replace The name of the object to replace (if different to the
+     * @template TService of object
+     * @template TReplace of object
+     * @param TService $service The object to register
+     * @param class-string<TReplace>|string|null $replace The name of the object to replace (if different to the
      * class name of the object to register)
      * @return $this
      */
@@ -915,7 +919,8 @@ class Injector implements ContainerInterface
      * Removes a named object from the cached list of objects managed
      * by the inject
      *
-     * @param string $name The name to unregister
+     * @template T of object
+     * @param class-string<T>|string $name The name to unregister
      * @return $this
      */
     public function unregisterNamedObject($name)
@@ -966,12 +971,13 @@ class Injector implements ContainerInterface
      *
      * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
      *
-     * @param string $name The name of the service to retrieve. If not a registered
+     * @template T of object
+     * @param class-string<T> $name The name of the service to retrieve. If not a registered
      * service, then a class of the given name is instantiated
      * @param bool $asSingleton If set to false a new instance will be returned.
      * If true a singleton will be returned unless the spec is type=prototype'
      * @param array $constructorArgs Args to pass in to the constructor. Note: Ignored for singletons
-     * @return mixed Instance of the specified object
+     * @return ($name is class-string<T> ? T : mixed) Instance of the specified object
      */
     public function get($name, $asSingleton = true, $constructorArgs = [])
     {
@@ -987,12 +993,13 @@ class Injector implements ContainerInterface
     /**
      * Returns the service, or `null` if it doesnt' exist. See {@link get()} for main usage.
      *
-     * @param string $name The name of the service to retrieve. If not a registered
+     * @template T of object
+     * @param class-string<T> $name The name of the service to retrieve. If not a registered
      * service, then a class of the given name is instantiated
      * @param bool $asSingleton If set to false a new instance will be returned.
      * If true a singleton will be returned unless the spec is type=prototype'
      * @param array $constructorArgs Args to pass in to the constructor. Note: Ignored for singletons
-     * @return mixed Instance of the specified object
+     * @return ($name is class-string<T> ? T : mixed) Instance of the specified object
      */
     protected function getNamedService($name, $asSingleton = true, $constructorArgs = [])
     {
@@ -1125,9 +1132,10 @@ class Injector implements ContainerInterface
      *
      * Additional parameters are passed through as
      *
-     * @param string $name
+     * @template T of object
+     * @param class-string<T> $name
      * @param mixed ...$argument arguments to pass to the constructor
-     * @return mixed A new instance of the specified object
+     * @return ($name is class-string<T> ? T : mixed) A new instance of the specified object
      */
     public function create($name, $argument = null)
     {
@@ -1139,9 +1147,10 @@ class Injector implements ContainerInterface
     /**
      * Creates an object with the supplied argument array
      *
-     * @param string $name Name of the class to create an object of
+     * @template T of object
+     * @param class-string<T>|string $name Name of the class to create an object of
      * @param array $constructorArgs Arguments to pass to the constructor
-     * @return mixed
+     * @return ($name is class-string<T> ? T : mixed)
      */
     public function createWithArgs($name, $constructorArgs)
     {

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -15,8 +15,9 @@ use SilverStripe\Core\Manifest\ModuleManifest;
  * way to access instance methods which don't rely on instance
  * data (e.g. the custom SilverStripe static handling).
  *
- * @param string $className
- * @return mixed
+ * @template T of object
+ * @param class-string<T> $className
+ * @return ($className is class-string<T> ? T : mixed)
  */
 function singleton($className)
 {

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -17,7 +17,8 @@ use SilverStripe\Core\Manifest\ModuleManifest;
  *
  * @template T of object
  * @param class-string<T> $className
- * @return ($className is class-string<T> ? T : mixed)
+ * @return mixed
+ * @phpstan-return ($className is class-string<T> ? T : mixed)
  */
 function singleton($className)
 {

--- a/tests/php/Type/InjectorTypeTest.php
+++ b/tests/php/Type/InjectorTypeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\Type\Tests;
+
+use Generator;
+use PHPStan\Testing\TypeInferenceTestCase;
+use function glob;
+
+class InjectorTypeTest extends TypeInferenceTestCase
+{
+    public function typeFileAsserts(): Generator
+    {
+        $typeTests = glob(__DIR__ . '/data/injector-types.php') ?: [];
+
+        foreach ($typeTests as $typeTest) {
+            yield from $this->gatherAssertTypes($typeTest);
+        }
+    }
+
+    /**
+     * @dataProvider typeFileAsserts
+     */
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/php/Type/data/injector-types.php
+++ b/tests/php/Type/data/injector-types.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\Type\Tests\data;
+
+use SilverStripe\Assets\File;
+use SilverStripe\Core\Injector\Injector;
+use function PHPStan\Testing\assertType;
+
+assertType(
+    File::class,
+    Injector::inst()->get(File::class)
+);
+
+assertType(
+    File::class,
+    singleton(File::class)
+);
+
+assertType(
+    File::class,
+    Injector::inst()->create(File::class)
+);
+
+assertType(
+    File::class,
+    Injector::inst()->createWithArgs(File::class, ['Name' => 'Foo'])
+);


### PR DESCRIPTION
Resolves #1 

## Caveats
- Must use return conditions to pass type tests, phpstan thinks that a return type of `T|mixed` is always `mixed`
