### PR TITLE
MNT Add generics to ArrayList - Better IDE friendly version

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -29,6 +29,8 @@ use Traversable;
  *   - sort
  *   - filter
  *   - exclude
+ *
+ * @template T
  */
 class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, Limitable
 {
@@ -45,13 +47,12 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Holds the items in the list
      *
-     * @var array
+     * @var array<array-key, T>
      */
     protected $items = [];
 
     /**
-     *
-     * @param array $items - an initial array to fill this object with
+     * @param array<array-key, T> $items - an initial array to fill this object with
      */
     public function __construct(array $items = [])
     {
@@ -62,14 +63,14 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Underlying type class for this list
      *
-     * @var string
+     * @var class-string<T>|null
      */
     protected $dataClass = null;
 
     /**
      * Return the class of items in this list, by looking at the first item inside it.
      *
-     * @return string
+     * @return class-string<T>|null
      */
     public function dataClass()
     {
@@ -85,7 +86,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Hint this list to a specific type
      *
-     * @param string $class
+     * @param class-string<T> $class
      * @return $this
      */
     public function setDataClass($class)
@@ -116,6 +117,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Returns an Iterator for this ArrayList.
      * This function allows you to use ArrayList in foreach loops
+     *
+     * @return iterable<array-key, T>
      */
     public function getIterator(): Traversable
     {
@@ -131,7 +134,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Return an array of the actual items that this ArrayList contains.
      *
-     * @return array
+     * @return T[]
      */
     public function toArray()
     {
@@ -216,7 +219,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Add this $item into this list
      *
-     * @param mixed $item
+     * @param array|object $item
      */
     public function add($item)
     {
@@ -226,7 +229,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Remove this item from this list
      *
-     * @param mixed $item
+     * @param array|object $item
      */
     public function remove($item)
     {
@@ -263,7 +266,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * Merges with another array or list by pushing all the items in it onto the
      * end of this list.
      *
-     * @param array|object $with
+     * @param iterable $with
      */
     public function merge($with)
     {
@@ -345,7 +348,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Returns the first item in the list
      *
-     * @return mixed
+     * @return T|null
      */
     public function first()
     {
@@ -359,7 +362,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Returns the last item in the list
      *
-     * @return mixed
+     * @return T|null
      */
     public function last()
     {
@@ -425,7 +428,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Reverses an {@link ArrayList}
      *
-     * @return ArrayList
+     * @return static<T>
      */
     public function reverse()
     {
@@ -479,12 +482,13 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * Note that columns may be double quoted as per ANSI sql standard
      *
-     * @return static
      * @see SS_List::sort()
      * @example $list->sort('Name'); // default ASC sorting
      * @example $list->sort('Name DESC'); // DESC sorting
      * @example $list->sort('Name', 'ASC');
      * @example $list->sort(array('Name'=>'ASC,'Age'=>'DESC'));
+     *
+     * @return static<T>
      */
     public function sort()
     {
@@ -597,7 +601,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @param string $key
      * @param string $value
-     * @return mixed
+     * @return T|null
      */
     public function find($key, $value)
     {
@@ -607,7 +611,6 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Filter the list to include items with these characteristics
      *
-     * @return ArrayList
      * @see Filterable::filter()
      * @example $list->filter('Name', 'bob'); // only bob in the list
      * @example $list->filter('Name', array('aziz', 'bob'); // aziz and bob in list
@@ -619,6 +622,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * Also supports SearchFilter syntax
      * @example // include anyone with "sam" anywhere in their name
      *          $list = $list->filter('Name:PartialMatch', 'sam');
+     *
+     * @return static<T>
      */
     public function filter()
     {
@@ -645,7 +650,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *          $list = $list->filterAny('Name:PartialMatch', 'sam');
      *
      * @param string|array See {@link filter()}
-     * @return static
+     * @return static<T>
      */
     public function filterAny()
     {
@@ -656,7 +661,6 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Exclude the list to not contain items with these characteristics
      *
-     * @return ArrayList
      * @see SS_List::exclude()
      * @example $list->exclude('Name', 'bob'); // exclude bob from list
      * @example $list->exclude('Name', array('aziz', 'bob'); // exclude aziz and bob from list
@@ -668,6 +672,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * Also supports SearchFilter syntax
      * @example // everyone except anyone with "sam" anywhere in their name
      *          $list = $list->exclude('Name:PartialMatch', 'sam');
+     *
+     * @return static<T>
      */
     public function exclude()
     {
@@ -694,6 +700,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *          $list = $list->excludeAny('Name:PartialMatch', 'sam');
      *
      * @param string|array See {@link filter()}
+     * @return static<T>
      */
     public function excludeAny(): static
     {
@@ -703,6 +710,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
 
     /**
      * Apply the appropriate filtering or excluding
+     *
+     * @return static<T>
      */
     protected function filterOrExclude(array $filters, bool $inclusive = true, bool $any = false): static
     {
@@ -840,7 +849,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * Filter this list to only contain the given Primary IDs
      *
      * @param array $ids Array of integers, will be automatically cast/escaped.
-     * @return ArrayList
+     *
+     * @return static<T>
      */
     public function byIDs($ids)
     {
@@ -864,7 +874,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @example $list = $list->filterByCallback(function($item, $list) { return $item->Age == 9; })
      * @param callable $callback
-     * @return ArrayList
+     *
+     * @return static<T>
      */
     public function filterByCallback($callback)
     {

--- a/src/ORM/EagerLoadedList.php
+++ b/src/ORM/EagerLoadedList.php
@@ -194,7 +194,7 @@ class EagerLoadedList extends ViewableData implements Relation, SS_List, Filtera
     }
 
     /**
-     * @return iterator<T>
+     * @return iterable<array-key, T>
      */
     public function getIterator(): Traversable
     {

--- a/src/ORM/UnsavedRelationList.php
+++ b/src/ORM/UnsavedRelationList.php
@@ -125,7 +125,7 @@ class UnsavedRelationList extends ArrayList implements Relation
     /**
      * Returns an Iterator for this relation.
      *
-     * @return iterator<T>
+     * @return iterable<array-key, T>
      */
     public function getIterator(): Traversable
     {


### PR DESCRIPTION
This works fairly nicely in my IDE. It's much better than #14 because it reports the correct type with no unions or bad data - with one caveat:

```php
/** @var ArrayList<string[]> $list */
$list = new ArrayList([
    [
        'SomeField' => 'SomeValue',
    ],
]);

// It doesn't know it's wrapping these in ArrayData, so we end up with the wrong type here.
foreach ($list as $item) {
    /** @var string[] $item */
}
```

Also, calling `$list->setDataClass(MyClass::class)` still has no effect - though I guess technically it shouldn't, since the iterator won't actually change what it's returning based on this method...

## Conclusion

I think this is probably the right way forward for this - it works great in my IDE (which won't support conditional return types), with only one exception. I'd argue that people should be explicitly wrapping their associative arrays inside `ArrayData` if that's what they want them to be - and a phpstan rule could proably be fairly easily created to ensure that's the case for projects that care about that stuff.

## Issue
- https://github.com/silverstripeltd/silverstripe-framework-generics/issues/9