### PR TITLE
MNT Add generic arguments to Extension

### DIFF
--- a/src/Core/Extension.php
+++ b/src/Core/Extension.php
@@ -13,6 +13,8 @@ use SilverStripe\ORM\DataObject;
  * Every object instance gets its own set of extension instances,
  * meaning you can set parameters specific to the "owner instance"
  * in new Extension instances.
+ *
+ * @template T of object
  */
 abstract class Extension
 {
@@ -25,7 +27,7 @@ abstract class Extension
     /**
      * The object this extension is applied to.
      *
-     * @var Object
+     * @var T
      */
     protected $owner;
 
@@ -95,7 +97,7 @@ abstract class Extension
     /**
      * Returns the owner of this extension.
      *
-     * @return Object
+     * @return T
      */
     public function getOwner()
     {

--- a/src/ORM/DataExtension.php
+++ b/src/ORM/DataExtension.php
@@ -14,7 +14,7 @@ use Exception;
  * An extension that adds additional functionality to a {@link DataObject}.
  *
  * @template T of DataObject
- * @extends Extension<T|static>
+ * @extends Extension<T>
  */
 abstract class DataExtension extends Extension
 {

--- a/src/ORM/DataExtension.php
+++ b/src/ORM/DataExtension.php
@@ -13,7 +13,8 @@ use Exception;
 /**
  * An extension that adds additional functionality to a {@link DataObject}.
  *
- * @property DataObject $owner
+ * @template T of DataObject
+ * @extends Extension<T|static>
  */
 abstract class DataExtension extends Extension
 {

--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -23,8 +23,8 @@ use SilverStripe\View\ViewableData;
  * obvious example of this is SiteTree.
  *
  * @property int $ParentID
- * @property DataObject|Hierarchy $owner
  * @method DataObject Parent()
+ * @extends DataExtension<DataObject|static>
  */
 class Hierarchy extends DataExtension
 {
@@ -119,8 +119,7 @@ class Hierarchy extends DataExtension
     public function validate(ValidationResult $validationResult)
     {
         // The object is new, won't be looping.
-        /** @var DataObject|Hierarchy $owner */
-        $owner = $this->owner;
+        $owner = $this->getOwner();
         if (!$owner->ID) {
             return;
         }

--- a/tests/php/Type/ExtensionTypeTest.php
+++ b/tests/php/Type/ExtensionTypeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SilverStripe\Type\Tests;
+
+use Generator;
+use PHPStan\Testing\TypeInferenceTestCase;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Type\Tests\Source\ExtensibleMockOne;
+use SilverStripe\Type\Tests\Source\ExtensibleMockTwo;
+use SilverStripe\Type\Tests\Source\ExtensionMockOne;
+use SilverStripe\Type\Tests\Source\ExtensionMockTwo;
+use function glob;
+
+class ExtensionTypeTest extends TypeInferenceTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Config::modify()->merge(
+            ExtensibleMockOne::class,
+            'extensions',
+            [
+                ExtensionMockOne::class,
+                ExtensionMockTwo::class,
+            ]
+        );
+
+        Config::modify()->merge(
+            ExtensibleMockTwo::class,
+            'extensions',
+            [
+                ExtensionMockTwo::class,
+            ]
+        );
+    }
+
+    public function typeFileAsserts(): Generator
+    {
+        $typeTests = glob(__DIR__ . '/data/extension-types.php') ?: [];
+
+        foreach ($typeTests as $typeTest) {
+            yield from $this->gatherAssertTypes($typeTest);
+        }
+    }
+
+    /**
+     * @dataProvider typeFileAsserts
+     */
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/phpstan.neon.dist'];
+    }
+}

--- a/tests/php/Type/Source/ExtensibleMockOne.php
+++ b/tests/php/Type/Source/ExtensibleMockOne.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Type\Tests\Source;
+
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Dev\TestOnly;
+
+class ExtensibleMockOne implements TestOnly
+{
+    use Extensible;
+    use Configurable;
+}

--- a/tests/php/Type/Source/ExtensibleMockTwo.php
+++ b/tests/php/Type/Source/ExtensibleMockTwo.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Type\Tests\Source;
+
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Dev\TestOnly;
+
+class ExtensibleMockTwo implements TestOnly
+{
+    use Extensible;
+    use Configurable;
+}

--- a/tests/php/Type/Source/ExtensionMockOne.php
+++ b/tests/php/Type/Source/ExtensionMockOne.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Type\Tests\Source;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+/**
+ * @extends Extension<ExtensibleMockOne|static>
+ */
+class ExtensionMockOne extends Extension implements TestOnly
+{
+}

--- a/tests/php/Type/Source/ExtensionMockTwo.php
+++ b/tests/php/Type/Source/ExtensionMockTwo.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Type\Tests\Source;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+/**
+ * @extends Extension<ExtensibleMockOne|ExtensibleMockTwo|static>
+ */
+class ExtensionMockTwo extends Extension implements TestOnly
+{
+}

--- a/tests/php/Type/Source/ExtensionMockTwo.php
+++ b/tests/php/Type/Source/ExtensionMockTwo.php
@@ -2,12 +2,12 @@
 
 namespace SilverStripe\Type\Tests\Source;
 
-use SilverStripe\Core\Extension;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataExtension;
 
 /**
- * @extends Extension<ExtensibleMockOne|ExtensibleMockTwo|static>
+ * @extends DataExtension<ExtensibleMockOne|ExtensibleMockTwo|static>
  */
-class ExtensionMockTwo extends Extension implements TestOnly
+class ExtensionMockTwo extends DataExtension implements TestOnly
 {
 }

--- a/tests/php/Type/data/extension-types.php
+++ b/tests/php/Type/data/extension-types.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SilverStripe\Type\Tests\data;
+
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Type\Tests\Source\ExtensibleMockOne;
+use SilverStripe\Type\Tests\Source\ExtensibleMockTwo;
+use SilverStripe\Type\Tests\Source\ExtensionMockOne;
+use SilverStripe\Type\Tests\Source\ExtensionMockTwo;
+use function PHPStan\Testing\assertType;
+
+$extensionOne = Injector::inst()->get(ExtensionMockOne::class);
+$extensionTwo = Injector::inst()->get(ExtensionMockTwo::class);
+
+assertType(
+    sprintf('%s|static(%s)', ExtensibleMockOne::class, ExtensionMockOne::class),
+    $extensionOne->getOwner()
+);
+
+assertType(
+    sprintf(
+        '%s|%s|static(%s)',
+        ExtensibleMockOne::class,
+        ExtensibleMockTwo::class,
+        ExtensionMockTwo::class
+    ),
+    $extensionTwo->getOwner()
+);

--- a/tests/php/Type/phpstan-bootstrap.php
+++ b/tests/php/Type/phpstan-bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+use SilverStripe\Core\DatabaselessKernel;
+
+$kernel = new class(BASE_PATH) extends DatabaselessKernel {
+    public function getIncludeTests()
+    {
+        return true;
+    }
+};
+
+try {
+    $kernel->boot();
+} catch (\Throwable) {
+}

--- a/tests/php/Type/phpstan.neon.dist
+++ b/tests/php/Type/phpstan.neon.dist
@@ -1,0 +1,3 @@
+parameters:
+	bootstrapFiles:
+		- phpstan-bootstrap.php


### PR DESCRIPTION
Add generics to `Extension` and `DataExtension`

## Gotchas
- PHPStan needs a running Silverstripe application in order to access the Configuration API. Currently bootstrapping, see `phpstan-bootstrap.php`
- A common convention for `getOwner()` is the `@method Foo|$this getOwner()` property annotation. This can now be achieved using `@extends Extension<Foo|static>`
- Ideally we'd like to use `@extends Extension<Foo&static>` instead of the former mentioned above. But phpstan out-of-the-box resolves the type to `never`.

