### PR TITLE
MNT Add generics to ArrayList - testable version

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -29,6 +29,8 @@ use Traversable;
  *   - sort
  *   - filter
  *   - exclude
+ *
+ * @template T
  */
 class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, Limitable
 {
@@ -45,13 +47,12 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Holds the items in the list
      *
-     * @var array
+     * @var array<array-key, T>
      */
     protected $items = [];
 
     /**
-     *
-     * @param array $items - an initial array to fill this object with
+     * @param array<array-key, T> $items - an initial array to fill this object with
      */
     public function __construct(array $items = [])
     {
@@ -62,14 +63,14 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Underlying type class for this list
      *
-     * @var string
+     * @var class-string<T>|null
      */
     protected $dataClass = null;
 
     /**
      * Return the class of items in this list, by looking at the first item inside it.
      *
-     * @return string
+     * @return class-string<T>|null
      */
     public function dataClass()
     {
@@ -85,7 +86,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Hint this list to a specific type
      *
-     * @param string $class
+     * @param class-string<T> $class
      * @return $this
      */
     public function setDataClass($class)
@@ -116,6 +117,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Returns an Iterator for this ArrayList.
      * This function allows you to use ArrayList in foreach loops
+     *
+     * @return (T is array ? iterable<ArrayData> : iterable<T>)
      */
     public function getIterator(): Traversable
     {
@@ -131,7 +134,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Return an array of the actual items that this ArrayList contains.
      *
-     * @return array
+     * @return T[]
      */
     public function toArray()
     {
@@ -216,7 +219,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Add this $item into this list
      *
-     * @param mixed $item
+     * @param array|object $item
      */
     public function add($item)
     {
@@ -226,7 +229,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Remove this item from this list
      *
-     * @param mixed $item
+     * @param array|object $item
      */
     public function remove($item)
     {
@@ -263,7 +266,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * Merges with another array or list by pushing all the items in it onto the
      * end of this list.
      *
-     * @param array|object $with
+     * @param iterable $with
      */
     public function merge($with)
     {
@@ -345,7 +348,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Returns the first item in the list
      *
-     * @return mixed
+     * @return T|null
      */
     public function first()
     {
@@ -359,7 +362,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Returns the last item in the list
      *
-     * @return mixed
+     * @return T|null
      */
     public function last()
     {
@@ -425,7 +428,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Reverses an {@link ArrayList}
      *
-     * @return ArrayList
+     * @return static<T>
      */
     public function reverse()
     {
@@ -479,12 +482,13 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * Note that columns may be double quoted as per ANSI sql standard
      *
-     * @return static
      * @see SS_List::sort()
      * @example $list->sort('Name'); // default ASC sorting
      * @example $list->sort('Name DESC'); // DESC sorting
      * @example $list->sort('Name', 'ASC');
      * @example $list->sort(array('Name'=>'ASC,'Age'=>'DESC'));
+     *
+     * @return static<T>
      */
     public function sort()
     {
@@ -597,7 +601,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @param string $key
      * @param string $value
-     * @return mixed
+     * @return T|null
      */
     public function find($key, $value)
     {
@@ -607,7 +611,6 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Filter the list to include items with these characteristics
      *
-     * @return ArrayList
      * @see Filterable::filter()
      * @example $list->filter('Name', 'bob'); // only bob in the list
      * @example $list->filter('Name', array('aziz', 'bob'); // aziz and bob in list
@@ -619,6 +622,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * Also supports SearchFilter syntax
      * @example // include anyone with "sam" anywhere in their name
      *          $list = $list->filter('Name:PartialMatch', 'sam');
+     *
+     * @return static<T>
      */
     public function filter()
     {
@@ -645,7 +650,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *          $list = $list->filterAny('Name:PartialMatch', 'sam');
      *
      * @param string|array See {@link filter()}
-     * @return static
+     * @return static<T>
      */
     public function filterAny()
     {
@@ -656,7 +661,6 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     /**
      * Exclude the list to not contain items with these characteristics
      *
-     * @return ArrayList
      * @see SS_List::exclude()
      * @example $list->exclude('Name', 'bob'); // exclude bob from list
      * @example $list->exclude('Name', array('aziz', 'bob'); // exclude aziz and bob from list
@@ -668,6 +672,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * Also supports SearchFilter syntax
      * @example // everyone except anyone with "sam" anywhere in their name
      *          $list = $list->exclude('Name:PartialMatch', 'sam');
+     *
+     * @return static<T>
      */
     public function exclude()
     {
@@ -694,6 +700,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *          $list = $list->excludeAny('Name:PartialMatch', 'sam');
      *
      * @param string|array See {@link filter()}
+     * @return static<T>
      */
     public function excludeAny(): static
     {
@@ -703,6 +710,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
 
     /**
      * Apply the appropriate filtering or excluding
+     *
+     * @return static<T>
      */
     protected function filterOrExclude(array $filters, bool $inclusive = true, bool $any = false): static
     {
@@ -840,7 +849,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * Filter this list to only contain the given Primary IDs
      *
      * @param array $ids Array of integers, will be automatically cast/escaped.
-     * @return ArrayList
+     *
+     * @return static<T>
      */
     public function byIDs($ids)
     {
@@ -864,7 +874,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @example $list = $list->filterByCallback(function($item, $list) { return $item->Age == 9; })
      * @param callable $callback
-     * @return ArrayList
+     *
+     * @return static<T>
      */
     public function filterByCallback($callback)
     {

--- a/tests/php/Type/ArrayListTypeTest.php
+++ b/tests/php/Type/ArrayListTypeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\Type\Tests;
+
+use Generator;
+use PHPStan\Testing\TypeInferenceTestCase;
+use function glob;
+
+class ArrayListTypeTest extends TypeInferenceTestCase
+{
+    public function typeArrayListAsserts(): Generator
+    {
+        $typeTests = glob(__DIR__ . '/data/arraylist-types.php') ?: [];
+
+        foreach ($typeTests as $typeTest) {
+            yield from $this->gatherAssertTypes($typeTest);
+        }
+    }
+
+    /**
+     * @dataProvider typeArrayListAsserts
+     */
+    public function testArrayListAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/php/Type/data/arraylist-types.php
+++ b/tests/php/Type/data/arraylist-types.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SilverStripe\Type\Tests\data;
+
+use SilverStripe\Assets\File;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\View\ArrayData;
+
+use function PHPStan\Testing\assertType;
+
+assertType(
+    'iterable<' . File::class . '>',
+    (new ArrayList([new File()]))->getIterator()
+);
+
+assertType(
+    'iterable<' . ArrayData::class . '>',
+    (new ArrayList([
+        ['Field' => 'Value']
+    ]))->getIterator()
+);
+
+assertType(
+    'iterable<' . ArrayData::class . '>',
+    (new ArrayList([
+        new ArrayData(['Field' => 'Value'])
+    ]))->getIterator()
+);


### PR DESCRIPTION
This is basically identical to #15 except it conditionally returns from the iterator, resulting in always having the correct return type. This makes it testable, but has less IDE support.

Note however that:
1. These tests fail - it seems I fundamentally misunderstood how these tests work. I thought they were performing static analysis to validate that the PHPdocs gave the expected result after conditions were resolved - but they're actually testing the final runtime return type. So in this case, we get `Traversable`, not `iterable<ArrayData>`
2. My IDE actually treats this _identically_ to #15. I'm not sure how that works out, but it is what it is.

## Issue
- https://github.com/silverstripeltd/silverstripe-framework-generics/issues/9